### PR TITLE
fix: refactors error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # CHANGELOG
 
-## v0.6.2 (2021-09-03)
+## v0.7.0 (2021-09-06)
 
-* Code refactor cutting out redundant validation checks
+* Code refactor cutting out redundant validation checks, making error handling modular, and properly exiting Dots when an error occurs
 * We now properly initialize Dots when running the standalone `dots_source` function
+* Cleaned up `dots` namespace by prepending internal helper functions with an underscore (those functions that aren't intended to be used by users. This should assist with autocorrect)
 
 ## v0.6.1 (2021-09-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v0.6.2 (2021-09-03)
+
+* Code refactor cutting out redundant validation checks
+* We now properly initialize Dots when running the standalone `dots_source` function
+
 ## v0.6.1 (2021-09-02)
 
 * Separates `dots_check_shell` from `dots_init_message`

--- a/README.md
+++ b/README.md
@@ -148,7 +148,3 @@ dots_config_down() {
     fi
 }
 ```
-
-## Attribution
-
-* Icons made by <a href="" title="xnimrodx">xnimrodx</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a>

--- a/src/dots.sh
+++ b/src/dots.sh
@@ -2,15 +2,15 @@
 
 # User configurable variables
 DOTFILES_DIR="$HOME/.dotfiles"
-SHOW_INIT_MESSAGE="true" # Leave this empty if you don't want to show the init messages (eg: SHOW_INIT_MESSAGE=)
+SHOW_INIT_MESSAGE="true"  # Leave this empty if you don't want to show the init messages (eg: SHOW_INIT_MESSAGE=)
 
 # Dots required variables (do not edit)
 DOTS_VERSION="v0.6.1"
-HOSTNAME=$(hostname) # Required for macOS
+HOSTNAME=$(hostname)  # Required for macOS
 DOTS_SCRIPT="$DOTFILES_DIR/dots/src/dots.sh"
 DOTS_CONFIG_FILE="$DOTFILES_DIR/dots-config.sh"
-DOTFILES_URL="$DOTFILES_URL" # Yes, we recursively set this here because of our loop sourcing
-DOTFILES_GITHUB_USER="$(basename "$(dirname "$DOTFILES_URL")")" # Dynamically fill this based on the dotfiles URL
+DOTFILES_URL="$DOTFILES_URL"  # Yes, we recursively set this here because of our loop sourcing
+DOTFILES_GITHUB_USER="$(basename "$(dirname "$DOTFILES_URL")")"  # Dynamically fill this based on the dotfiles URL
 
 # TODO: Add a function that allows you to see what dotfiles were linked
 
@@ -20,25 +20,43 @@ dots_get_dotfiles_status() {
         dots_status
     else
         echo "Dotfiles directory does not exist."
+        return 1
     fi
 }
 
-# Ensures the shell being used is supported, warns if not
+# Ensures the dotfiles directory exists
+dots_check_dotfiles_dir() {
+    if [ ! -d "$DOTFILES_DIR" ] ; then
+        echo "Dotfiles directory does not exist."
+        return 1
+    fi
+}
+
+# Ensures the shell being used is supported
 dots_check_shell() {
-    if [ "$SHELL" != "/bin/zsh" ] && [ "$SHELL" != "/bin/bash" ] ; then
-        echo "Dots doesn't support $SHELL." && exit 1
+    if [ "$SHELL" != "/bin/zshs" ] && [ "$SHELL" != "/bin/bash" ] ; then
+        echo "Dots doesn't support $SHELL."
+        return 1
+    fi
+}
+
+# Ensures the Dots config file is present
+dots_check_config_file() {
+    if [ ! -f "$DOTS_CONFIG_FILE" ] ; then
+        echo "Dots couldn't find $DOTS_CONFIG_FILE."
+        return 1
     fi
 }
 
 # Anything that Dots needs upon initialization goes here
 dots_init() {
-    dots_check_shell
-
-    if [ "$SHELL" = "/bin/zsh" ] ; then
-       SHELL_CONFIG_FILE="$HOME/.zshrc"
-    elif [ "$SHELL" = "/bin/bash" ] ; then
-       SHELL_CONFIG_FILE="$HOME/.bash_profile"
-    fi
+    dots_check_shell && (
+        if [ "$SHELL" = "/bin/zsh" ] ; then
+        SHELL_CONFIG_FILE="$HOME/.zshrc"
+        elif [ "$SHELL" = "/bin/bash" ] ; then
+        SHELL_CONFIG_FILE="$HOME/.bash_profile"
+        fi
+    )
 }
 
 # Print Dotfiles message on each shell start (will be initialized from core shell file)
@@ -55,70 +73,60 @@ dots_init_message() {
 
 # Push Dotfiles up to the Git server
 dots_push() {
-    if [ -d "$DOTFILES_DIR" ] ; then
+    dots_check_dotfiles_dir && (
         echo "Pushing dotfiles..."
         git -C "$DOTFILES_DIR" add .
         git -C "$DOTFILES_DIR" commit -m "Updated dotfiles"
         git -C "$DOTFILES_DIR" push > /dev/null 2>&1 && echo "Dotfiles pushed!" || echo "Error pushing Dotfiles"
-    else
-        echo "Dotfiles directory does not exist."
-    fi
+    )
 }
 
 # Pull updates from the Dotfiles project
 dots_pull() {	
-    if [ -d "$DOTFILES_DIR" ] ; then
+    dots_check_dotfiles_dir && (
         echo "Pulling dotfiles..."
         git -C "$DOTFILES_DIR" pull --rebase > /dev/null 2>&1 && echo "Dotfiles pulled!" || echo "Error pulling Dotfiles"
-    else
-        echo "Dotfiles directory does not exist."
-    fi
+    )
 }
 
 # Resets the .zshrc/.bash_profile files to only contain Dots and the config
 dots_reset_terminal_config() {
-    dots_init # We initialize Dots here to properly set $SHELL_CONFIG_FILE
-
-    if [ "$SHELL" = "/bin/zsh" ] || [ "$SHELL" = "/bin/bash" ] ; then
+    dots_init && (
         {
             echo "# Dots Config";
             echo "DOTFILES_URL=\"$DOTFILES_URL\"";
             echo ". $DOTS_SCRIPT";
             echo ". $DOTS_CONFIG_FILE";
-            echo "dots_init"
+            echo "dots_init";
             if [ "$SHOW_INIT_MESSAGE" ] ; then
                 echo "dots_init_message";
             fi
             echo "";
             echo "# Dotfiles Config";
         } > "$SHELL_CONFIG_FILE"
-    fi
+    )
 }
 
-# Installs the newly pulled dotfiles
+# Installs dotfiles based on the Dots config file
 dots_install() {
-    if [ -f "$DOTS_CONFIG_FILE" ] ; then
+    dots_check_config_file && (
         dots_reset_terminal_config
         echo "Installing dotfiles..."
 
         # The `dots_config_up` command is sourced from "$DOTS_CONFIG_FILE":
         dots_config_up && echo "Dotfiles installed!" || echo "Error installing Dotfiles"
-    else
-        echo "Dots couldn't find $DOTS_CONFIG_FILE."
-    fi
+    )
 }
 
-# Cleans dotfiles
+# Cleans dotfiles based on the Dots config file
 dots_clean() {
-    if [ -f "$DOTS_CONFIG_FILE" ] ; then
+    dots_check_config_file && (
         dots_reset_terminal_config
         echo "Cleaning dotfiles..."
 
         # The `dots_config_down` command is sourced from "$DOTS_CONFIG_FILE":
         dots_config_down && echo "Dotfiles cleaned!" || echo "Error cleaning Dotfiles"
-    else
-        echo "Dots couldn't find $DOTS_CONFIG_FILE."
-    fi
+    )
 }
 
 # Gets the status of dotfiles
@@ -139,6 +147,8 @@ dots_sync() {
 
 # Sources the shell
 dots_source() {
-    . "$SHELL_CONFIG_FILE"
-    echo "Dotfiles sourced!"
+    dots_init && (
+        . "$SHELL_CONFIG_FILE"
+        echo "Dotfiles sourced!"
+    )
 }


### PR DESCRIPTION
TODO:

- We need to have validation and error handling functions "exit" the next steps of the process without killing off the terminal. Am messing with `exit` vs `return` at the moment.
- Rename internal functions as such with a leading underscore

Changes:

* Code refactor cutting out redundant validation checks
* We now properly initialize Dots when running the standalone `dots_source` function