### PR TITLE
feat: refactor for cleaner usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v1.0.0 (2021-11-21)
+
+* Refactored variables for easier installation (now requiring no parameters to the install script), better reuse of code, and correctly namespaced items
+    * `SHOW_DOTS_MESSAGE` is now `DOTS_SHOW_INIT_MESSAGE`
+    * `DOTFILES_URL` is no longer used anywhere and no longer needed (this also means the "Powered by ... Dotfiles" message is gone)
+* Fixed a bug that would throw an error if no shell config file was found on startup (this was problematic as we started assuming the user already had a shell config file; however, that may not be the case for a brand new machine getting setup with Dots)
+* Various other improvements made to the underlyinng code including refactor, comments, updated documentation, etc
+
 ## v0.9.0 (2021-11-19)
 
 * Adds support for `sh`, `dash`, and `ksh` shells by using the `~/.profile` (closes #5)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ git submodule update --remote dots
 
 **Dots Shell Initialization Message**
 
-If you would like to not show the Dots message on shell start, simply make the `DOTS_SHOW_DOTS_MESSAGE` variable found in `dots.sh` empty.
+If you would like to not show the Dots message on shell start, simply make the `DOTS_SHOW_INIT_MESSAGE` variable found in `dots.sh` empty.
 
 ## Configuration
 
@@ -103,7 +103,7 @@ The only thing Dots requires for configuration is a file in the root of your Dot
 ### Basic Configuration
 
 ```bash
-# The variable "DOTFILES_DIR" is available to use here (points to $HOME/.dotfiles)
+# The variable "DOTFILES_DIR" is available to use here (points to $HOME/.dotfiles by default)
 
 # Instructions run when installing/updating Dotfiles
 dots_config_up() {
@@ -112,19 +112,19 @@ dots_config_up() {
 
 # Instructions run when cleaning Dotfiles
 dots_config_down() {
-    rm -i "$HOME"/.gitconfig
+    rm "$HOME"/.gitconfig
 }
 ```
 
 ### Advanced Configuration
 
 ```bash
-# The variable "DOTFILES_DIR" is available to use here (points to $HOME/.dotfiles)
+# The variable "DOTFILES_DIR" is available to use here (points to $HOME/.dotfiles by default)
 
 # Instructions run when installing/updating Dotfiles
 dots_config_up() {
     # Specifying a hostname is completely optional, but an effective way to ensure
-    # computer-specific Dotfiles are installed properly. One config file can configure
+    # computer-specific Dotfiles are installed properly. One config file can setup
     # multiple computers depending on their HOSTNAME
     if [[ "$HOSTNAME" == "MacBook-Pro-Justin" ]] ; then
         ln -sfn "$DOTFILES_DIR"/src/personal/home/.gitconfig "$HOME"/.gitconfig

--- a/README.md
+++ b/README.md
@@ -27,13 +27,12 @@ Dots makes no assumptions as to how or where your dotfiles should be installed. 
 * Optionally prints info about your Dots on each shell start:
 
 ```
-################### Dots v0.6.1 ###################
+################### Dots v1.0.0 ###################
 Shell: /bin/zsh
 Hostname: MacBook-Pro-Justin
-Powered by Justintime50's Dotfiles
 
 Dotfiles status:
-## main...origin/main
+## main...origin/main [behind 1]
 ###################################################
 ```
 
@@ -55,8 +54,9 @@ git submodule add https://github.com/Justintime50/dots.git
 git clone https://github.com/USERNAME/dotfiles.git "$HOME/.dotfiles"
 git -C "$HOME/.dotfiles" submodule init && git -C "$HOME/.dotfiles" submodule update
 
-# 2) Install Dots (param 1 is the URL of your Dotfiles project, param 2 is your shell config file such as `.zshrc` or `.bash_profile`)
-$HOME/.dotfiles/dots/src/install.sh https://github.com/USERNAME/dotfiles.git .zshrc
+# 2) Install Dots
+# Installation assumes your dotfiles are are stored at `~/.dotfiles`; if not, alter the `DOTFILES_DIR` variable in `install.sh`
+$HOME/.dotfiles/dots/src/install.sh
 ```
 
 ## Usage
@@ -94,7 +94,7 @@ git submodule update --remote dots
 
 **Dots Shell Initialization Message**
 
-To not show the Dots message on shell start, simply make the `SHOW_DOTS_MESSAGE` variable found in `dots.sh` empty.
+If you would like to not show the Dots message on shell start, simply make the `DOTS_SHOW_DOTS_MESSAGE` variable found in `dots.sh` empty.
 
 ## Configuration
 

--- a/src/dots.sh
+++ b/src/dots.sh
@@ -1,6 +1,6 @@
 # Dots: The simple, flexible, Dotfile manager.
 
-# shellcheck disable=SC1090,SC2148
+# shellcheck disable=SC1090,SC1091,SC2148
 
 # User configurable variables
 DOTFILES_DIR="$HOME/.dotfiles"  # Cannot be `~/.dots` as we will use this for internal Dots usage
@@ -8,9 +8,10 @@ DOTS_SHOW_INIT_MESSAGE="true"  # Leave this empty if you don't want to show the 
 
 # Dots required variables (do not edit)
 DOTS_VERSION="v1.0.0"
-DOTS_DIR="$HOME/.dots"
 HOSTNAME="$(hostname)"  # Required for macOS as it's not set automatically like it is on Linux
-DOTS_SCRIPT_FILE="$DOTFILES_DIR/dots/src/dots.sh"
+DOTS_DIR="$HOME/.dots"
+DOTS_DOTFILES_DIR="$DOTFILES_DIR/dots/src"
+DOTS_SCRIPT_FILE="$DOTS_DOTFILES_DIR/dots.sh"
 DOTS_CONFIG_FILE="$DOTFILES_DIR/dots-config.sh"
 
 ### CHECKERS ###
@@ -63,7 +64,7 @@ _dots_get_dotfiles_status() {
 _dots_init() {
     if _dots_check_shell ; then
         # Source anything that's required for the installer and dots such as `_dots_set_shell_config_file`
-        . shared.sh
+        . "$DOTS_DOTFILES_DIR/shared.sh"
         _dots_set_shell_config_file  # Sourced from `shared.sh`
 
         mkdir -p "$DOTS_DIR"

--- a/src/dots.sh
+++ b/src/dots.sh
@@ -1,4 +1,5 @@
 # Dots: The simple, flexible, Dotfile manager.
+
 # shellcheck disable=SC1090,SC2148
 
 # User configurable variables
@@ -58,22 +59,13 @@ _dots_get_dotfiles_status() {
     fi
 }
 
-# Sets the SHELL_CONFIG_FILE variable based on the current shell in use
-_dots_set_shell_config_file() {
-    if [ "$SHELL" = "/bin/zsh" ] ; then
-        SHELL_CONFIG_FILE="$HOME/.zshrc"
-    elif [ "$SHELL" = "/bin/bash" ] ; then
-        SHELL_CONFIG_FILE="$HOME/.bash_profile"
-    elif [ "$SHELL" = "/bin/sh" ] || [ "$SHELL" = "/bin/dash" ] || [ "$SHELL" = "/bin/ksh" ] ; then
-        SHELL_CONFIG_FILE="$HOME/.profile"
-    fi
-}
-
 # Anything that Dots needs upon initialization goes here
 _dots_init() {
     if _dots_check_shell ; then
+        # Source anything that's required for the installer and dots such as `_dots_set_shell_config_file`
+        . shared.sh
         mkdir -p "$DOTS_DIR"
-        _dots_set_shell_config_file
+        _dots_set_shell_config_file  # Sourced from `shared.sh`
     else
         return 1
     fi

--- a/src/dots.sh
+++ b/src/dots.sh
@@ -1,29 +1,18 @@
-# shellcheck disable=SC1090,SC2148,SC2269
+# Dots: The simple, flexible, Dotfile manager.
+# shellcheck disable=SC1090,SC2148
 
 # User configurable variables
 DOTFILES_DIR="$HOME/.dotfiles"  # Cannot be `~/.dots` as we will use this for internal Dots usage
-SHOW_INIT_MESSAGE="true"  # Leave this empty if you don't want to show the init messages (eg: SHOW_INIT_MESSAGE=)
+DOTS_SHOW_INIT_MESSAGE="true"  # Leave this empty if you don't want to show the init messages (eg: DOTS_SHOW_INIT_MESSAGE=)
 
 # Dots required variables (do not edit)
-DOTS_VERSION="v0.9.0"
+DOTS_VERSION="v1.0.0"
 DOTS_DIR="$HOME/.dots"
-HOSTNAME=$(hostname)  # Required for macOS
-DOTS_SCRIPT="$DOTFILES_DIR/dots/src/dots.sh"
+HOSTNAME="$(hostname)"  # Required for macOS as it's not set automatically like it is on Linux
+DOTS_SCRIPT_FILE="$DOTFILES_DIR/dots/src/dots.sh"
 DOTS_CONFIG_FILE="$DOTFILES_DIR/dots-config.sh"
-DOTFILES_URL="$DOTFILES_URL"  # Yes, we recursively set this here because of our loop sourcing
-DOTFILES_GITHUB_USER="$(basename "$(dirname "$DOTFILES_URL")")"  # Dynamically fill this based on the dotfiles URL
 
-### HELPERS ###
-
-# Checks that dotfiles are up to date each time a terminal starts
- _dots_get_dotfiles_status() {
-    if [ -d "$DOTFILES_DIR" ] ; then
-        dots_status
-    else
-        echo "Dotfiles directory does not exist."
-        return 1
-    fi
-}
+### CHECKERS ###
 
 # Ensures the dotfiles directory exists
 _dots_check_dotfiles_dir() {
@@ -44,7 +33,7 @@ _dots_check_shell() {
 # Ensures the Dots config file exists
 _dots_check_config_file() {
     if [ ! -f "$DOTS_CONFIG_FILE" ] ; then
-        echo "Dots couldn't find $DOTS_CONFIG_FILE."
+        echo "Dots couldn't find DOTS_CONFIG_FILE."
         return 1
     fi
 }
@@ -52,8 +41,31 @@ _dots_check_config_file() {
 # Ensures the shell config file exists
 _dots_check_shell_config_file() {
     if [ ! -f "$SHELL_CONFIG_FILE" ] ; then
-        echo "Dots couldn't find $SHELL_CONFIG_FILE."
+        echo "Dots couldn't find SHELL_CONFIG_FILE."
         return 1
+    fi
+}
+
+### HELPERS ###
+
+# Checks that dotfiles are up to date each time a terminal starts
+_dots_get_dotfiles_status() {
+    if _dots_check_dotfiles_dir ; then
+        dots_status
+    else
+        echo "Dotfiles directory does not exist."
+        return 1
+    fi
+}
+
+# Sets the SHELL_CONFIG_FILE variable based on the current shell in use
+_dots_set_shell_config_file() {
+    if [ "$SHELL" = "/bin/zsh" ] ; then
+        SHELL_CONFIG_FILE="$HOME/.zshrc"
+    elif [ "$SHELL" = "/bin/bash" ] ; then
+        SHELL_CONFIG_FILE="$HOME/.bash_profile"
+    elif [ "$SHELL" = "/bin/sh" ] || [ "$SHELL" = "/bin/dash" ] || [ "$SHELL" = "/bin/ksh" ] ; then
+        SHELL_CONFIG_FILE="$HOME/.profile"
     fi
 }
 
@@ -61,13 +73,7 @@ _dots_check_shell_config_file() {
 _dots_init() {
     if _dots_check_shell ; then
         mkdir -p "$DOTS_DIR"
-        if [ "$SHELL" = "/bin/zsh" ] ; then
-            SHELL_CONFIG_FILE="$HOME/.zshrc"
-        elif [ "$SHELL" = "/bin/bash" ] ; then
-            SHELL_CONFIG_FILE="$HOME/.bash_profile"
-        elif [ "$SHELL" = "/bin/sh" ] || [ "$SHELL" = "/bin/dash" ] || [ "$SHELL" = "/bin/ksh" ] ; then
-            SHELL_CONFIG_FILE="$HOME/.profile"
-        fi
+        _dots_set_shell_config_file
     else
         return 1
     fi
@@ -77,29 +83,28 @@ _dots_init() {
 _dots_init_message() {
     echo "################### Dots $DOTS_VERSION ###################"
     echo "Shell: $SHELL"
-    echo "Hostname: $HOSTNAME"
-    echo "Powered by $DOTFILES_GITHUB_USER's Dotfiles"
+    echo "Hostname: $HOSTNAME"  # We print Hostname here to assist with multi-machine Dotfile management
     echo ""
-    echo "Dotfiles status: "
+    echo "Dotfiles status:"
     _dots_get_dotfiles_status
     echo "###################################################"
 }
 
-# Resets the .zshrc/.bash_profile files to only contain Dots and the config
+# Resets the `~/.zshrc`, `~/.bash_profile`, or `~/.profile` files to only contain Dots and the config
+# Be aware this will overwrite whatever the user has setup at those locations and create it if it doesn't exist
 _dots_reset_terminal_config() {
-    if _dots_init && _dots_check_shell_config_file ; then
+    if _dots_init ; then
         {
             echo "# Dots Config";
-            echo "DOTFILES_URL=\"$DOTFILES_URL\"";
-            echo ". $DOTS_SCRIPT";
+            echo ". $DOTS_SCRIPT_FILE";
             echo ". $DOTS_CONFIG_FILE";
             echo "_dots_init";
-            if [ "$SHOW_INIT_MESSAGE" ] ; then
+            if [ "$DOTS_SHOW_INIT_MESSAGE" ] ; then
                 echo "_dots_init_message";
             fi
             echo "";
             echo "# Dotfiles Config";
-        } > "$SHELL_CONFIG_FILE"
+        } > "$SHELL_CONFIG_FILE"  # If this file doesn't yet exist, it will be created here
     fi
 }
 

--- a/src/dots.sh
+++ b/src/dots.sh
@@ -64,8 +64,9 @@ _dots_init() {
     if _dots_check_shell ; then
         # Source anything that's required for the installer and dots such as `_dots_set_shell_config_file`
         . shared.sh
-        mkdir -p "$DOTS_DIR"
         _dots_set_shell_config_file  # Sourced from `shared.sh`
+
+        mkdir -p "$DOTS_DIR"
     else
         return 1
     fi
@@ -87,7 +88,7 @@ _dots_init_message() {
 _dots_reset_terminal_config() {
     if _dots_init ; then
         {
-            echo "# Dots Config";
+            echo "# Dots Config (automatically set, do not edit)";
             echo ". $DOTS_SCRIPT_FILE";
             echo ". $DOTS_CONFIG_FILE";
             echo "_dots_init";
@@ -95,7 +96,7 @@ _dots_reset_terminal_config() {
                 echo "_dots_init_message";
             fi
             echo "";
-            echo "# Dotfiles Config";
+            echo "# Dotfiles Config (custom, edit below this line)";
         } > "$SHELL_CONFIG_FILE"  # If this file doesn't yet exist, it will be created here
     fi
 }

--- a/src/install.sh
+++ b/src/install.sh
@@ -13,7 +13,7 @@ main() {
     _dots_set_shell_config_file  # Sourced from `shared.sh`
     
     # Add Dots as a sourced script to your current shell config (running this install script will overwrite your shell config file)
-    echo ". $DOTFILES_DIR/dots/src/dots.sh" >> "$SHELL_CONFIG_FILE"
+    echo ". $DOTS_DOTFILES_DIR/dots.sh" >> "$SHELL_CONFIG_FILE"
     echo ". $DOTFILES_DIR/dots-config.sh" >> "$SHELL_CONFIG_FILE"
 
     # Source the SHELL_CONFIG_FILE so we can call `dots_sync`

--- a/src/install.sh
+++ b/src/install.sh
@@ -1,30 +1,23 @@
 #!/bin/sh
 
+# This script will install Dots initially on your system
+
 # shellcheck disable=SC1090
 
 DOTFILES_DIR="$HOME/.dotfiles"
 
 main() {
     # Sets SHELL_CONFIG_FILE for our use
-    _dots_set_shell_config_file
+    . shared.sh
+    _dots_set_shell_config_file  # Sourced from `shared.sh`
     
     # Add Dots as a sourced script to your current shell config (running this install script will overwrite your shell config file)
     echo ". $DOTFILES_DIR/dots/src/dots.sh" >> "$SHELL_CONFIG_FILE"
     echo ". $DOTFILES_DIR/dots-config.sh" >> "$SHELL_CONFIG_FILE"
 
+    # Source the SHELL_CONFIG_FILE so we can call `dots_sync`
     . "$SHELL_CONFIG_FILE"
-    dots_sync  # This is sourced from the SHELL_CONFIG_FILE
-}
-
-# Sets the SHELL_CONFIG_FILE variable based on the current shell in use
-_dots_set_shell_config_file() {
-    if [ "$SHELL" = "/bin/zsh" ] ; then
-        SHELL_CONFIG_FILE="$HOME/.zshrc"
-    elif [ "$SHELL" = "/bin/bash" ] ; then
-        SHELL_CONFIG_FILE="$HOME/.bash_profile"
-    elif [ "$SHELL" = "/bin/sh" ] || [ "$SHELL" = "/bin/dash" ] || [ "$SHELL" = "/bin/ksh" ] ; then
-        SHELL_CONFIG_FILE="$HOME/.profile"
-    fi
+    dots_sync
 }
 
 main

--- a/src/install.sh
+++ b/src/install.sh
@@ -2,13 +2,14 @@
 
 # This script will install Dots initially on your system
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 
 DOTFILES_DIR="$HOME/.dotfiles"
+DOTS_DOTFILES_DIR="$DOTFILES_DIR/dots/src"
 
 main() {
     # Sets SHELL_CONFIG_FILE for our use
-    . shared.sh
+    . "$DOTS_DOTFILES_DIR/shared.sh"
     _dots_set_shell_config_file  # Sourced from `shared.sh`
     
     # Add Dots as a sourced script to your current shell config (running this install script will overwrite your shell config file)

--- a/src/install.sh
+++ b/src/install.sh
@@ -1,23 +1,30 @@
-#!/bin/bash
+#!/bin/sh
 
 # shellcheck disable=SC1090
 
 DOTFILES_DIR="$HOME/.dotfiles"
-SHELL_CONFIG_FILE="$HOME/$2"
 
 main() {
-    if [ -n "$1" ] && [ -n "$2" ] ; then
-        # Add Dots as a sourced script to your current shell config
-        echo ". $DOTFILES_DIR/dots/src/dots.sh" >> "$SHELL_CONFIG_FILE"
-        echo ". $DOTFILES_DIR/dots-config.sh" >> "$SHELL_CONFIG_FILE"
+    # Sets SHELL_CONFIG_FILE for our use
+    _dots_set_shell_config_file
+    
+    # Add Dots as a sourced script to your current shell config (running this install script will overwrite your shell config file)
+    echo ". $DOTFILES_DIR/dots/src/dots.sh" >> "$SHELL_CONFIG_FILE"
+    echo ". $DOTFILES_DIR/dots-config.sh" >> "$SHELL_CONFIG_FILE"
 
-        # Run `dots_sync` the first time specifying the DOTFILES_URL of your project (replace USERNAME)
-        . "$SHELL_CONFIG_FILE"
-        DOTFILES_URL="$1" dots_sync
-    else
-        echo "Could not install Dots due to missing parameters."
-        exit 1
+    . "$SHELL_CONFIG_FILE"
+    dots_sync  # This is sourced from the SHELL_CONFIG_FILE
+}
+
+# Sets the SHELL_CONFIG_FILE variable based on the current shell in use
+_dots_set_shell_config_file() {
+    if [ "$SHELL" = "/bin/zsh" ] ; then
+        SHELL_CONFIG_FILE="$HOME/.zshrc"
+    elif [ "$SHELL" = "/bin/bash" ] ; then
+        SHELL_CONFIG_FILE="$HOME/.bash_profile"
+    elif [ "$SHELL" = "/bin/sh" ] || [ "$SHELL" = "/bin/dash" ] || [ "$SHELL" = "/bin/ksh" ] ; then
+        SHELL_CONFIG_FILE="$HOME/.profile"
     fi
 }
 
-main "$@"
+main

--- a/src/shared.sh
+++ b/src/shared.sh
@@ -1,0 +1,14 @@
+# This file contains functions that are required for both the installer and Dots itself
+
+# shellcheck disable=SC2148,SC2034
+
+# Sets the SHELL_CONFIG_FILE variable based on the current shell in use
+_dots_set_shell_config_file() {
+    if [ "$SHELL" = "/bin/zsh" ] ; then
+        SHELL_CONFIG_FILE="$HOME/.zshrc"
+    elif [ "$SHELL" = "/bin/bash" ] ; then
+        SHELL_CONFIG_FILE="$HOME/.bash_profile"
+    elif [ "$SHELL" = "/bin/sh" ] || [ "$SHELL" = "/bin/dash" ] || [ "$SHELL" = "/bin/ksh" ] ; then
+        SHELL_CONFIG_FILE="$HOME/.profile"
+    fi
+}


### PR DESCRIPTION
* Refactored variables for easier installation (now requiring no parameters to the install script), better reuse of code, and correctly namespaced items
    * `SHOW_DOTS_MESSAGE` is now `DOTS_SHOW_INIT_MESSAGE`
    * `DOTFILES_URL` is no longer used anywhere and no longer needed (this also means the "Powered by ... Dotfiles" message is gone)
* Fixed a bug that would throw an error if no shell config file was found on startup (this was problematic as we started assuming the user already had a shell config file; however, that may not be the case for a brand new machine getting setup with Dots)
* Various other improvements made to the underlyinng code including refactor, comments, updated documentation, etc